### PR TITLE
GH action to spin up test app

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,8 +41,8 @@ jobs:
     - name: Checkout datastar repository
       uses: actions/checkout@v4
       with:
-        repository: gazpachoking/datastar
-        ref: fix-go-sdk-tests
+        repository: ismasan/datastar
+        ref: go_sdk_tests
         path: datastar
 
     - name: Set up Go

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,60 @@
+name: Test Ruby Gem with Rack App
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.3.5
+        bundler-cache: true
+    
+    - name: Install dependencies
+      run: |
+        bundle install
+        gem install bundler
+    
+    - name: Run unit tests
+      run: bundle exec rspec
+    
+    - name: Start Rack test app
+      run: |
+        # Start the test app in background on port 9292
+        bundle exec puma examples/test.ru &
+        
+        # Store the PID for cleanup
+        echo $! > rack_app.pid
+        
+        # Wait for the app to start
+        sleep 5
+        
+        # Verify the app is running
+        curl -f http://localhost:9292/ || (echo "App failed to start" && exit 1)
+      
+    - name: Run integration tests
+      run: |
+        curl -f http://localhost:9292/ || (echo "App failed to start" && exit 1)
+        # Make the test script executable
+        # chmod +x test/integration_test.rb
+        
+        # Run the integration tests
+        # ruby test/integration_test.rb
+      env:
+        TEST_APP_URL: http://localhost:9292
+    
+    - name: Cleanup
+      if: always()
+      run: |
+        # Kill the Rack app if it's still running
+        if [ -f rack_app.pid ]; then
+          kill $(cat rack_app.pid) 2>/dev/null || true
+          rm rack_app.pid
+        fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,6 @@ name: Test Ruby Gem with Rack App
 
 on:
   push:
-  pull_request:
 
 jobs:
   test:
@@ -27,29 +26,35 @@ jobs:
     
     - name: Start Rack test app
       run: |
-        # Start the test app in background on port 9292
-        bundle exec puma examples/test.ru &
+        # Start the test app in background on port 8000
+        bundle exec puma -p 8000 examples/test.ru &
         
         # Store the PID for cleanup
         echo $! > rack_app.pid
         
         # Wait for the app to start
-        sleep 5
+        sleep 3
         
         # Verify the app is running
-        curl -f http://localhost:9292/ || (echo "App failed to start" && exit 1)
-      
-    - name: Run integration tests
-      run: |
-        curl -f http://localhost:9292/ || (echo "App failed to start" && exit 1)
-        # Make the test script executable
-        # chmod +x test/integration_test.rb
-        
-        # Run the integration tests
-        # ruby test/integration_test.rb
-      env:
-        TEST_APP_URL: http://localhost:9292
-    
+        curl -f http://localhost:8000/ || (echo "App failed to start" && exit 1)
+
+    - name: Checkout datastar repository
+      uses: actions/checkout@v4
+      with:
+        repository: gazpachoking/datastar
+        ref: fix-go-sdk-tests
+        path: datastar
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.22'
+        cache-dependency-path: datastar/sdk/tests
+
+    - name: Run SDK tests against test server
+      working-directory: datastar/sdk/tests
+      run: go run ./cmd/datastar-sdk-tests -server http://localhost:8000 
+
     - name: Cleanup
       if: always()
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,8 +41,8 @@ jobs:
     - name: Checkout datastar repository
       uses: actions/checkout@v4
       with:
-        repository: ismasan/datastar
-        ref: go_sdk_tests
+        repository: starfederation/datastar
+        ref: develop
         path: datastar
 
     - name: Set up Go

--- a/examples/test.ru
+++ b/examples/test.ru
@@ -32,7 +32,7 @@ run do |env|
   end
 
   datastar.stream do |sse|
-    sse.signals['events'].each do |event|
+    (sse.signals['events'] || []).each do |event|
       type = event.delete('type')
       case type
       when 'patchSignals'


### PR DESCRIPTION
A Github action that:

* Installs dependencies for this SDK
* Runs unit tests
* Starts a test app on `localhost:8000`
* Pulls main `datastar` repo and installs Go
* Runs SDK tests in main D* repo at `./sdk/tests` with `go run` against running test app for the SDK.

Once [this datastar PR](https://github.com/starfederation/datastar/pull/1007) is merged, I can update the GH action with the main repo's path.