### PR TITLE
Do not block server request threads when launching streaming threads

### DIFF
--- a/lib/datastar/server_sent_event_generator.rb
+++ b/lib/datastar/server_sent_event_generator.rb
@@ -24,6 +24,9 @@ module Datastar
 
     attr_reader :signals
 
+    # @param stream [IO, Queue] The IO stream or Queue to write to
+    # @option signals [Hash] A hash of signals (params)
+    # @option view_context [Object] The view context for rendering elements, if applicable.
     def initialize(stream, signals:, view_context: nil)
       @stream = stream
       @signals = signals

--- a/spec/support/dispatcher_examples.rb
+++ b/spec/support/dispatcher_examples.rb
@@ -19,6 +19,7 @@ module DispatcherExamples
 
       socket = TestSocket.new
       dispatcher.response.body.call(socket)
+      socket.wait_for_close
       expect(socket.open).to be(false)
       expect(socket.lines.size).to eq(2)
       expect(socket.lines[0]).to eq("event: datastar-patch-signals\ndata: signals {\"foo\":\"bar\"}\n\n")
@@ -45,6 +46,7 @@ module DispatcherExamples
 
       socket = TestSocket.new
       dispatcher.response.body.call(socket)
+      socket.wait_for_close
       expect(errs.first).to be_a(ArgumentError)
       Thread.report_on_exception = true
     end


### PR DESCRIPTION
Instead, handle streaming queue in a new thread (which serialises writes to the connection socket, and handlers errors such as IOError, Errno::EPIPE triggering callbacks.

This is so that the server's request thread (ie Puma) can be quickly returned to the pool. Servers like Falcon (fibers instead of threads) should not have this problem, but they should still work fine with this (they will spawn an extra fiber, but that should be cheap).

Possible issues:

This change decouples the server's thread pool from Datastar's streaming threads, which ATM are unbounded (an app with long-lived streams could potentially spawn thousands of threads even if the server is configured with a limited pool.

This can be problematic, because:

* The server can run out of resources
* If the streams rely on services such as database connections, they could quickly drain those connection pools.

Possible solution: provide configuration for a separate, Datastar-specific thread-pool so that it can be tweaked as per available resources (such as database pools)

context: https://blog.appsignal.com/2024/11/20/rack-for-ruby-socket-hijacking.html