### PR TITLE
Bump version to 1.0.0-rc.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    datastar (1.0.0)
+    datastar (1.0.0.pre.rc.6)
       json
       logger
       rack (>= 3.1.14)

--- a/lib/datastar/version.rb
+++ b/lib/datastar/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Datastar
-  VERSION = '1.0.0'
+  VERSION = '1.0.0-rc.6'
 end


### PR DESCRIPTION
Note that this sorts lower than 1.0.0.
It needs to be required with --pre, or the explicit full version

```ruby
gem "mygem", "1.0.0-rc.6"
# or
gem "mygem", prerelease: true
```