### PR TITLE
Remove Connection response header in Async (Fibers) mode

### DIFF
--- a/lib/datastar/async_executor.rb
+++ b/lib/datastar/async_executor.rb
@@ -22,7 +22,9 @@ module Datastar
 
     def new_queue = Async::Queue.new
 
-    def prepare(response); end
+    def prepare(response)
+      response.delete_header 'Connection'
+    end
 
     def spawn(&block)
       Async(&block)

--- a/spec/async_executor_spec.rb
+++ b/spec/async_executor_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+RSpec.describe Datastar::AsyncExecutor do
+  it 'removes Connection header from response' do
+    executor = described_class.new
+    response = Rack::Response.new(nil, 200, { 'Connection' => 'keep-alive'})
+    executor.prepare(response)
+    expect(response.headers.key?('Connection')).to be(false)
+  end
+end


### PR DESCRIPTION
The Falcon Ruby server (currently the option for Fiber-based concurrency) ignores "hop headers" such as Connection, and displays a warning in HTTP mode (it just removes them in HTTPS)

https://github.com/socketry/falcon/blob/8292c26f6972b88149bc1dc5f9abb1f9c66ca039/lib/falcon/middleware/proxy.rb#L35

When using the AsyncExecutor (ie running under Falcon), remove the Connection header from the Response.