### PR TITLE
chore: bump Ruby to 3.3, use symbols for ElementPatchMode

### DIFF
--- a/datastar.gemspec
+++ b/datastar.gemspec
@@ -10,10 +10,11 @@ Gem::Specification.new do |spec|
 
   spec.summary = 'Ruby SDK for Datastar. Rack-compatible.'
   spec.homepage = 'https://github.com/starfederation/datastar-ruby#readme'
-  spec.required_ruby_version = '>= 3.0.0'
+  spec.required_ruby_version = '>= 3.3.0'
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/starfederation/datastar-ruby'
+  spec.metadata['rubygems_mfa_required'] = 'true'
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
@@ -29,9 +30,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   # Uncomment to register a new dependency of your gem
-  spec.add_dependency 'rack', '>= 3.2'
   spec.add_dependency 'json'
   spec.add_dependency 'logger'
+  spec.add_dependency 'rack', '>= 3.2'
 
   spec.add_development_dependency 'phlex'
   # For more information and examples about making a new gem, check out our

--- a/lib/datastar/server_sent_event_generator.rb
+++ b/lib/datastar/server_sent_event_generator.rb
@@ -5,28 +5,28 @@ require 'json'
 module Datastar
   module ElementPatchMode
     # Morphs the element into the existing element.
-    OUTER = 'outer'
+    OUTER = :outer
 
     # Replaces the inner HTML of the existing element.
-    INNER = 'inner'
+    INNER = :inner
 
     # Removes the existing element.
-    REMOVE = 'remove'
+    REMOVE = :remove
 
     # Replaces the existing element with the new element.
-    REPLACE = 'replace'
+    REPLACE = :replace
 
     # Prepends the element inside to the existing element.
-    PREPEND = 'prepend'
+    PREPEND = :prepend
 
     # Appends the element inside the existing element.
-    APPEND = 'append'
+    APPEND = :append
 
     # Inserts the element before the existing element.
-    BEFORE = 'before'
+    BEFORE = :before
 
     # Inserts the element after the existing element.
-    AFTER = 'after'
+    AFTER = :after
   end
 
   class ServerSentEventGenerator
@@ -98,7 +98,7 @@ module Datastar
 
     def remove_elements(selector, options = BLANK_OPTIONS)
       patch_elements(
-        nil, 
+        nil,
         options.merge(
           MODE_DATALINE_LITERAL => ElementPatchMode::REMOVE,
           selector:
@@ -178,7 +178,7 @@ module Datastar
           default_value = OPTION_DEFAULTS[sse_key]
           buffer << "#{sse_key}: #{v}\n" unless v == default_value
         elsif v.is_a?(Hash)
-          v.each do |kk, vv| 
+          v.each do |kk, vv|
             buffer << "data: #{k} #{kk} #{vv}\n"
           end
         elsif v.is_a?(Array)


### PR DESCRIPTION
Drop rubies version that should never reach the stars.

Less object allocation ==> faster gem.