### PR TITLE
Update Rack to >= 3.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     datastar (1.0.1)
       json
       logger
-      rack (>= 3.1.14)
+      rack (>= 3.2)
 
 GEM
   remote: https://rubygems.org/
@@ -48,7 +48,7 @@ GEM
       stringio
     puma (6.6.0)
       nio4r (~> 2.0)
-    rack (3.1.14)
+    rack (3.2.4)
     rake (13.2.1)
     rdoc (6.11.0)
       psych (>= 4.0.0)

--- a/datastar.gemspec
+++ b/datastar.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   # Uncomment to register a new dependency of your gem
-  spec.add_dependency 'rack', '>= 3.1.14'
+  spec.add_dependency 'rack', '>= 3.2'
   spec.add_dependency 'json'
   spec.add_dependency 'logger'
 


### PR DESCRIPTION
Rack 3.1.x breaks on Ruby 4 because of missing cgi/cookie. Seems to be related to https://github.com/rack/rack/pull/2335