### PR TITLE
Update Async to 2.35 remove deprecations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,13 +9,13 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    async (2.21.3)
+    async (2.35.2)
       console (~> 1.29)
       fiber-annotation
-      io-event (~> 1.7)
+      io-event (~> 1.11)
       metrics (~> 0.12)
-      traces (~> 0.15)
-    console (1.29.2)
+      traces (~> 0.18)
+    console (1.34.2)
       fiber-annotation
       fiber-local (~> 1.1)
       json
@@ -27,16 +27,16 @@ GEM
     fiber-annotation (0.2.0)
     fiber-local (1.1.0)
       fiber-storage
-    fiber-storage (1.0.0)
+    fiber-storage (1.0.1)
     io-console (0.8.0)
-    io-event (1.7.5)
+    io-event (1.14.2)
     irb (1.15.1)
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    json (2.9.1)
+    json (2.18.0)
     logger (1.7.0)
-    metrics (0.12.1)
+    metrics (0.15.0)
     nio4r (2.7.4)
     phlex (2.3.1)
       zeitwerk (~> 2.7)
@@ -68,7 +68,7 @@ GEM
       rspec-support (~> 3.13.0)
     rspec-support (3.13.2)
     stringio (3.1.2)
-    traces (0.15.2)
+    traces (0.18.2)
     zeitwerk (2.7.3)
 
 PLATFORMS


### PR DESCRIPTION
This only affects tests, since Async is not a hard runtime dependency.