### PR TITLE
Duplicate request passed to Dispatcher

### DIFF
--- a/lib/datastar/dispatcher.rb
+++ b/lib/datastar/dispatcher.rb
@@ -56,7 +56,10 @@ module Datastar
       @queue = nil
       @executor = executor
       @view_context = view_context
-      @request = request
+      # Dup the env so that Rack middleware restores (e.g. Rack::URLMap's
+      # ensure block resetting SCRIPT_NAME/PATH_INFO after app.call returns)
+      # don't affect async stream fibers that run after the handler returns.
+      @request = Rack::Request.new(request.env.dup)
       @response = Rack::Response.new(BLANK_BODY, 200, response&.headers || {})
       @response.content_type = SSE_CONTENT_TYPE
       @response.headers['Cache-Control'] = 'no-cache'

--- a/spec/dispatcher_spec.rb
+++ b/spec/dispatcher_spec.rb
@@ -63,6 +63,26 @@ RSpec.describe Datastar::Dispatcher do
       request.env['SERVER_PROTOCOL'] = 'HTTP/2.0'
       expect(dispatcher.response['Connection']).to be_nil
     end
+
+    it 'wraps the request in a new Rack::Request with a duplicated env' do
+      expect(dispatcher.request).not_to equal(request)
+      expect(dispatcher.request.env).not_to equal(request.env)
+    end
+
+    it 'isolates the dispatcher from later env mutations by upstream middleware' do
+      request.env['PATH_INFO'] = '/events'
+      request.env['SCRIPT_NAME'] = '/app'
+      dispatcher = Datastar.new(request:, response:, view_context:)
+
+      # Simulate middleware such as Rack::URLMap restoring SCRIPT_NAME/PATH_INFO
+      # in an ensure block after the handler returns but while async stream
+      # fibers are still running.
+      request.env['PATH_INFO'] = '/'
+      request.env['SCRIPT_NAME'] = ''
+
+      expect(dispatcher.request.path_info).to eq('/events')
+      expect(dispatcher.request.script_name).to eq('/app')
+    end
   end
 
   specify '.from_rack_env' do


### PR DESCRIPTION
So that we have a snapshot of the request in case Rack middleware mutates the original request

## The problem

Rack middleware such as [Rack::URLMap](https://www.rubydoc.info/gems/rack/Rack/URLMap) (used for mounting Rack apps under a path prefix) adds the prefix to `Request#env['SCRIPT_NAME']`, and then clear it out once the mounted app as served a response.

```ruby
map '/sourced' do
  run MyMountedApp
end
```

However, Datastar's async fibers run _after_ the host app has returned a response, by which time the middleware has reset the script name from `'/sourced'` back to `''`. Any code (such as template rendering) that assumes the expected path prefix  (ex for URL building) will break.

## The solution

When initialising the Datastar Dispatcher, make sure to make a copy of the request, so that middleware mutating the original request doesn't mutate the one held by SSE fibers.