### PR TITLE
CI: run matrix against Ruby 3.2, 3.3, 3.4, 4.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - '3.1'
           - '3.2'
           - '3.3'
           - '3.4'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,34 +2,47 @@ name: Test Ruby Gem with Rack App
 
 on:
   push:
+  pull_request:
 
 jobs:
   test:
     runs-on: ubuntu-latest
-    
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - '3.1'
+          - '3.2'
+          - '3.3'
+          - '3.4'
+          - '4.0'
+
+    name: Ruby ${{ matrix.ruby }}
+
     steps:
     - uses: actions/checkout@v4
-    
-    - name: Set up Ruby
+
+    - name: Set up Ruby ${{ matrix.ruby }}
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '4.0'
+        ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
-    
+
     - name: Run unit tests
       run: bundle exec rspec
-    
+
     - name: Start Rack test app
       run: |
         # Start the test app in background on port 8000
         bundle exec puma -p 8000 examples/test.ru &
-        
+
         # Store the PID for cleanup
         echo $! > rack_app.pid
-        
+
         # Wait for the app to start
         sleep 3
-        
+
         # Verify the app is running
         curl -f http://localhost:8000/ || (echo "App failed to start" && exit 1)
 
@@ -48,7 +61,7 @@ jobs:
 
     - name: Run SDK tests against test server
       working-directory: datastar/sdk/tests
-      run: go run ./cmd/datastar-sdk-tests -server http://localhost:8000 
+      run: go run ./cmd/datastar-sdk-tests -server http://localhost:8000
 
     - name: Cleanup
       if: always()


### PR DESCRIPTION
## Summary
- Adds a Ruby version matrix (`3.2`, `3.3`, `3.4`, `4.0`) to the existing test workflow so unit tests and the Datastar SDK conformance suite run end-to-end against every supported Ruby.
- Enables the workflow on `pull_request` events (previously only `push`).
- `fail-fast: false` so one Ruby's failure doesn't mask issues on the others.

## Effective Ruby floor: 3.2
The gemspec advertises `required_ruby_version >= 3.0.0`, but two factors raise the actual floor:

1. **Source uses Ruby 3.1+ shorthand hash literals** — e.g. `Datastar.new(request:, response:, view_context:)` in `lib/datastar.rb:23` and many specs.
2. **Transitive runtime dep `console 1.34.2`** (pulled in by `async`) requires `ruby >= 3.2`. Confirmed on CI: `bundle install` on Ruby 3.1 fails with:
   ```
   console-1.34.2 requires ruby version >= 3.2,
   which is incompatible with the current version, 3.1.7
   ```

So 3.2 is the lowest Ruby the project can actually be installed on. Matrix starts there. Aligning the gemspec floor to `>= 3.2.0` is intentionally left as a follow-up (out of scope for this PR).

## Commits
- `2fc739b` — initial matrix including 3.1
- `7a55c5f` — drop 3.1 after CI revealed the `console` floor

These can be squashed on merge if preferred.

## CI verification
Verified on a fork before opening this PR. All 4 Ruby versions pass unit specs + the Datastar SDK conformance suite.

## Test plan
- [ ] Workflow runs successfully on this PR for every matrix entry
- [ ] Unit tests pass on every Ruby version
- [ ] Datastar SDK conformance suite passes on every Ruby version