### PR TITLE
Lock x86_64-linux platform in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,7 @@ GEM
 PLATFORMS
   arm64-darwin-24
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   async


### PR DESCRIPTION
## Summary
- Adds `x86_64-linux` to the `PLATFORMS` section of `Gemfile.lock` via `bundle lock --add-platform x86_64-linux`.
- One-line change.

## Why
CI runs on `ubuntu-latest` (`x86_64-linux`). The lockfile only contained `arm64-darwin-24` and `ruby`, so on every CI run Bundler had to re-resolve and install platform-specific native gems instead of using the locked versions. Locking the platform keeps CI reproducible and avoids surprises when a gem ships a Linux-only native build that resolves differently from what's used locally.

## Test plan
- [ ] CI install step succeeds on `ubuntu-latest`
- [ ] `bundle exec rspec` still green on `arm64-darwin`