### PR TITLE
Allow Dispatcher to inject a custom generator_class

### DIFF
--- a/lib/datastar/dispatcher.rb
+++ b/lib/datastar/dispatcher.rb
@@ -37,6 +37,9 @@ module Datastar
     # @option error_callback [Proc] the callback to call when an error occurs
     # @option finalize [Proc] the callback to call when the response is finalized
     # @option heartbeat [Integer, nil, FalseClass] the heartbeat interval in seconds
+    # @option generator_class [Class] the generator class instantiated for each stream;
+    #   defaults to {ServerSentEventGenerator}. Pass a subclass to layer behavior
+    #   (logging, metrics, input scrubbing, etc.) without monkey-patching.
     def initialize(
       request:,
       response: nil,
@@ -45,7 +48,8 @@ module Datastar
       error_callback: Datastar.config.error_callback,
       finalize: Datastar.config.finalize,
       heartbeat: Datastar.config.heartbeat,
-      compression: Datastar.config.compression
+      compression: Datastar.config.compression,
+      generator_class: ServerSentEventGenerator
     )
       @on_connect = []
       @on_client_disconnect = []
@@ -56,6 +60,7 @@ module Datastar
       @queue = nil
       @executor = executor
       @view_context = view_context
+      @generator_class = generator_class
       # Dup the env so that Rack middleware restores (e.g. Rack::URLMap's
       # ensure block resetting SCRIPT_NAME/PATH_INFO after app.call returns)
       # don't affect async stream fibers that run after the handler returns.
@@ -301,7 +306,7 @@ module Datastar
     def stream_one(streamer)
       proc do |socket|
         socket = wrap_socket(socket)
-        generator = ServerSentEventGenerator.new(socket, signals:, view_context: @view_context)
+        generator = @generator_class.new(socket, signals:, view_context: @view_context)
         @on_connect.each { |callable| callable.call(generator) }
         handling_sync_errors(generator, socket) do
           streamer.call(generator)
@@ -328,14 +333,14 @@ module Datastar
       proc do |socket|
         socket = wrap_socket(socket)
         signs = signals
-        conn_generator = ServerSentEventGenerator.new(socket, signals: signs, view_context: @view_context)
+        conn_generator = @generator_class.new(socket, signals: signs, view_context: @view_context)
         @on_connect.each { |callable| callable.call(conn_generator) }
 
         threads = @streamers.map do |streamer|
           duped_signals = signs.dup.freeze
           @executor.spawn do
             # TODO: Review thread-safe view context
-            generator = ServerSentEventGenerator.new(@queue, signals: duped_signals, view_context: @view_context)
+            generator = @generator_class.new(@queue, signals: duped_signals, view_context: @view_context)
             streamer.call(generator)
             @queue << :done
           rescue StandardError => e

--- a/spec/dispatcher_spec.rb
+++ b/spec/dispatcher_spec.rb
@@ -730,6 +730,62 @@ RSpec.describe Datastar::Dispatcher do
     end
   end
 
+  describe ':generator_class' do
+    it 'defaults to Datastar::ServerSentEventGenerator' do
+      expect(Datastar::ServerSentEventGenerator).to receive(:new).and_call_original
+
+      dispatcher = Datastar.new(request:, response:, view_context:)
+      dispatcher.patch_signals(foo: 'bar')
+
+      socket = TestSocket.new
+      dispatcher.response.body.call(socket)
+    end
+
+    it 'instantiates the provided class for one-off responses (stream_one)' do
+      custom = Class.new(Datastar::ServerSentEventGenerator)
+      expect(custom).to receive(:new).and_call_original
+
+      dispatcher = Datastar.new(request:, response:, view_context:, generator_class: custom)
+      dispatcher.patch_signals(foo: 'bar')
+
+      socket = TestSocket.new
+      dispatcher.response.body.call(socket)
+    end
+
+    it 'instantiates the provided class for every concurrent stream and the connection generator (stream_many)' do
+      custom = Class.new(Datastar::ServerSentEventGenerator)
+      # 1 connection generator + 2 per-stream generators = 3
+      expect(custom).to receive(:new).at_least(3).times.and_call_original
+
+      dispatcher = Datastar.new(request:, response:, view_context:, generator_class: custom, heartbeat: false)
+      dispatcher.stream { |sse| sse.patch_signals(foo: 1) }
+      dispatcher.stream { |sse| sse.patch_signals(bar: 2) }
+
+      socket = TestSocket.new
+      dispatcher.response.body.call(socket)
+      socket.wait_for_close
+    end
+
+    it 'lets a subclass observe every event written to the stream' do
+      observed = []
+      custom = Class.new(Datastar::ServerSentEventGenerator) do
+        define_method(:write) do |buffer|
+          observed << buffer.dup
+          super(buffer)
+        end
+      end
+
+      dispatcher = Datastar.new(request:, response:, view_context:, generator_class: custom)
+      dispatcher.patch_signals(foo: 'bar')
+
+      socket = TestSocket.new
+      dispatcher.response.body.call(socket)
+
+      expect(observed.size).to eq(1)
+      expect(observed.first).to include('datastar-patch-signals')
+    end
+  end
+
   private
 
   # Binary socket for compression tests


### PR DESCRIPTION
## Summary
Adds an optional `generator_class:` keyword to `Datastar::Dispatcher#initialize` (defaulting to `ServerSentEventGenerator`). The three internal generator instantiations — `stream_one`, `stream_many`'s connection generator, and each per-stream generator inside spawned threads — now go through the injected class.

## Why
Downstream wrappers around Datastar (e.g. [`vibes-datastar`](https://github.com/rubakas/vibes/tree/main/gems/vibes-datastar)) need to layer behavior on top of the SSE generator: input scrubbing, logging, metrics, debug capture, etc. Today the only option is monkey-patching `ServerSentEventGenerator`, because the dispatcher hard-codes the class at three call sites — and the user code inside `Dispatcher#stream { |sse| ... }` always receives an SDK-instantiated generator. Letting the dispatcher accept a subclass is the standard "let the wrapper override the workhorse class" hook.

This is the smaller, orthogonal change discussed in the comment thread on #18.

## API
```ruby
class ScrubbingGenerator < Datastar::ServerSentEventGenerator
  def patch_elements(elements, options = BLANK_OPTIONS)
    super(scrub(elements), scrub_options(options))
  end
  # ...
end

datastar = Datastar.new(
  request:, response:, view_context:,
  generator_class: ScrubbingGenerator,
)
```

## Tests
4 new specs under \`Dispatcher :generator_class\`:
- defaults to \`Datastar::ServerSentEventGenerator\`
- one-off responses (\`stream_one\`) use the injected class
- multi-stream responses (\`stream_many\`) use it for the connection generator and every per-stream generator
- a subclass overriding \`#write\` observes every event written to the stream

Full suite: 104 examples, 0 failures.

## Notes
- This is intentionally Dispatcher-local; no \`Datastar.config\` symmetry yet. Trivial to add later if needed.
- Related to #18. With this hook, downstream wrappers can ship their scrubbing fix today via a subclass while a canonical fix in \`ServerSentEventGenerator\` is pursued separately.

## Test plan
- [ ] CI green
- [ ] Existing call sites still work (default behavior preserved)