### PR TITLE
Encode redirect URL as a safe JS string literal

### DIFF
--- a/lib/datastar/server_sent_event_generator.rb
+++ b/lib/datastar/server_sent_event_generator.rb
@@ -147,7 +147,16 @@ module Datastar
     end
 
     def redirect(url)
-      execute_script %(setTimeout(() => { window.location = '#{url}' }))
+      # Encode the URL as a JS string literal that's safe to embed inside <script>:
+      # - JSON.generate(..., ascii_only: true) escapes quotes, backslashes, control
+      #   chars, and U+2028/U+2029 (which are line terminators inside JS string
+      #   literals, so they break out without escaping).
+      # - escape_slash: true escapes / to \/ so a '</script>' substring in the
+      #   URL can't prematurely close the surrounding <script> tag during HTML
+      #   parsing — \/ is a no-op inside a JS string literal but the parser
+      #   doesn't recognize <\/script> as a script-end tag.
+      js_string = JSON.generate(url.to_s, ascii_only: true, escape_slash: true)
+      execute_script %(setTimeout(() => { window.location = #{js_string} }))
     end
 
     def write(buffer)

--- a/spec/dispatcher_spec.rb
+++ b/spec/dispatcher_spec.rb
@@ -349,7 +349,80 @@ RSpec.describe Datastar::Dispatcher do
       socket = TestSocket.new
       dispatcher.response.body.call(socket)
       expect(socket.open).to be(false)
-      expect(socket.lines).to eq([%(event: datastar-patch-elements\ndata: selector body\ndata: mode append\ndata: elements <script data-effect="el.remove()">setTimeout(() => { window.location = '/guide' })</script>\n\n)])
+      expect(socket.lines).to eq([%(event: datastar-patch-elements\ndata: selector body\ndata: mode append\ndata: elements <script data-effect="el.remove()">setTimeout(() => { window.location = "\\/guide" })</script>\n\n)])
+    end
+
+    it 'wraps single quotes inside a double-quoted JS string literal so they cannot break out' do
+      # Pre-fix: window.location = '/foo'); alert(1); ('';
+      #   → the ' in the URL closed the JS string and ); alert(1); ( ran as JS (XSS).
+      # Post-fix: window.location = "/foo'); alert(1); ('"
+      #   → JSON.generate emits a double-quoted literal; ' has no special meaning
+      #     inside ", so the breakout payload is harmless content of the URL value.
+      dispatcher.redirect("/foo'); alert(1); ('")
+      socket = TestSocket.new
+      dispatcher.response.body.call(socket)
+      output = socket.lines.join
+
+      # The breakout payload appears as inert string content of the URL
+      # (leading / is escape_slashed to \/, harmless in JS)
+      expect(output).to include(%[window.location = "\\/foo'); alert(1); ('"])
+      # The wrapping <script>…</script> stays balanced — no premature close
+      expect(output.scan('<script').size).to eq(1)
+      expect(output.scan('</script>').size).to eq(1)
+    end
+
+    it 'JS-escapes double quotes in URL' do
+      dispatcher.redirect('/foo"); alert(1); ("')
+      socket = TestSocket.new
+      dispatcher.response.body.call(socket)
+      output = socket.lines.join
+
+      expect(output).not_to include('"); alert(1); ("')
+      expect(output).to include('\\"')
+    end
+
+    it 'JS-escapes backslashes in URL' do
+      dispatcher.redirect('/foo\\"); alert(1); //')
+      socket = TestSocket.new
+      dispatcher.response.body.call(socket)
+      output = socket.lines.join
+
+      # The literal sequence "); from the payload must not appear unescaped
+      expect(output).not_to include('"); alert(1); //')
+    end
+
+    it 'escapes </script> so it cannot prematurely close the surrounding <script> tag' do
+      dispatcher.redirect('/foo</script><script>alert(1)</script>')
+      socket = TestSocket.new
+      dispatcher.response.body.call(socket)
+      output = socket.lines.join
+
+      # The wrapping <script>...</script> stays intact: only one closing tag,
+      # at the very end. The injected </script><script>alert(1)</script>
+      # becomes <\/script><script>alert(1)<\/script> inside the JS string.
+      expect(output).not_to match(%r{</script><script>alert\(1\)})
+      expect(output.scan('</script>').size).to eq(1)
+    end
+
+    it 'escapes U+2028 line separator (a JS string-literal terminator)' do
+      dispatcher.redirect("/foo bar")
+      socket = TestSocket.new
+      dispatcher.response.body.call(socket)
+      output = socket.lines.join
+
+      # Must be escaped to   so the JS string literal stays intact
+      expect(output).to include('\\u2028')
+      expect(output).not_to include(" ")
+    end
+
+    it 'escapes U+2029 paragraph separator (also a JS string-literal terminator)' do
+      dispatcher.redirect("/foo bar")
+      socket = TestSocket.new
+      dispatcher.response.body.call(socket)
+      output = socket.lines.join
+
+      expect(output).to include('\\u2029')
+      expect(output).not_to include(" ")
     end
   end
 


### PR DESCRIPTION
## Summary
Fixes a JS string-literal injection in `ServerSentEventGenerator#redirect`. The URL was previously interpolated raw inside a single-quoted JS string:

```ruby
def redirect(url)
  execute_script %(setTimeout(() => { window.location = '#{url}' }))
end
```

A `'` in `url` broke out of the literal, letting attacker-influenced fragments execute as JS.

## Realistic attack pattern

```ruby
datastar.redirect("/dashboard?ref=#{params[:ref]}")
```

This is a Rails idiom — `redirect_to` accepts the same shape and is safe — so developers reasonably assume Datastar's `redirect` is also safe. With attacker-controlled `params[:ref]`, pre-fix the rendered JS becomes:

\`\`\`js
window.location = '/dashboard?ref=x'); alert('credential-theft'); ('' 
\`\`\`

→ executes the alert.

## Fix

Encode the URL with `JSON.generate(url.to_s, ascii_only: true, escape_slash: true)`. The output is a properly-quoted JS string literal that:

- escapes `\"`, `\\`, and control characters,
- escapes **U+2028 / U+2029** (which terminate JS string literals even when delimited by `\"` or `'`),
- escapes `/` → `\\/` so a `</script>` substring in the URL can't prematurely close the surrounding `<script>` tag during HTML parsing. The HTML parser does not recognize `<\\/script>` as the end tag, while `\\/` is a no-op inside a JS string literal.

Post-fix output for the same attack:

\`\`\`js
window.location = \"\\/dashboard?ref=x'); alert('credential-theft'); ('\"
\`\`\`

The breakout payload sits as inert content inside the double-quoted literal. Just a normal redirect to a weird URL.

## Behavior change

`window.location` is now wrapped in **double quotes with JSON-style escapes** instead of single quotes. Functionally identical for safe URLs — the runtime navigation target is the same. One existing snapshot test was updated to reflect the new output format.

## Tests

6 new specs covering single quotes, double quotes, backslashes, `</script>` breakout, U+2028, and U+2029. Full suite: 106 examples, 0 failures.

## Test plan
- [ ] CI green
- [ ] Existing redirect regression test still passes (with updated snapshot)
- [ ] New attack-vector specs all pass