### PR TITLE
Make multi-stream disconnect callbacks mutually exclusive

### DIFF
--- a/lib/datastar/dispatcher.rb
+++ b/lib/datastar/dispatcher.rb
@@ -330,6 +330,11 @@ module Datastar
         signs = signals
         conn_generator = ServerSentEventGenerator.new(socket, signals: signs, view_context: @view_context)
         @on_connect.each { |callable| callable.call(conn_generator) }
+        # Track terminal state so on_server_disconnect fires only on normal
+        # completion — matches stream_one's mutually-exclusive callback contract
+        # (one of on_server_disconnect / on_client_disconnect / on_error per
+        # stream lifecycle, never combinations).
+        completed_normally = true
 
         threads = @streamers.map do |streamer|
           duped_signals = signs.dup.freeze
@@ -357,6 +362,7 @@ module Datastar
               done_count += 1
               @queue << nil if done_count == threads_size
             elsif data.is_a?(Exception)
+              completed_normally = false
               handle_streaming_error(data, socket)
               @queue << nil
             else
@@ -365,6 +371,7 @@ module Datastar
               begin
                 socket << data
               rescue Exception => e
+                completed_normally = false
                 handle_streaming_error(e, socket)
                 @queue << nil
               end
@@ -372,7 +379,7 @@ module Datastar
           end
 
         ensure
-          @on_server_disconnect.each { |callable| callable.call(conn_generator) }
+          @on_server_disconnect.each { |callable| callable.call(conn_generator) } if completed_normally
           @executor.stop(threads) if threads
           socket.close
         end

--- a/spec/support/dispatcher_examples.rb
+++ b/spec/support/dispatcher_examples.rb
@@ -50,6 +50,59 @@ module DispatcherExamples
       expect(errs.first).to be_a(ArgumentError)
       Thread.report_on_exception = true
     end
+
+    # Mutually-exclusive callback contract — matches stream_one's
+    # handling_sync_errors semantics: per stream lifecycle, exactly one
+    # of on_server_disconnect / on_client_disconnect / on_error fires.
+    it 'does not fire on_server_disconnect when a streamer raises (multi-stream)' do
+      Thread.report_on_exception = false
+      events = []
+
+      dispatcher = Datastar
+                    .new(request:, response:, executor:)
+                    .on_server_disconnect { |_| events << :server_disconnect }
+                    .on_error { |_| events << :error }
+
+      dispatcher.stream do |sse|
+        sleep 0.01
+        raise ArgumentError, 'boom'
+      end
+
+      dispatcher.stream do |sse|
+        sse.patch_signals(foo: 'bar')
+      end
+
+      socket = TestSocket.new
+      dispatcher.response.body.call(socket)
+      socket.wait_for_close
+      expect(events).to include(:error)
+      expect(events).not_to include(:server_disconnect)
+      Thread.report_on_exception = true
+    end
+
+    it 'does not fire on_server_disconnect when client disconnects mid-stream (multi-stream)' do
+      events = []
+
+      dispatcher = Datastar
+                    .new(request:, response:, executor:)
+                    .on_server_disconnect { |_| events << :server_disconnect }
+                    .on_client_disconnect { |_| events << :client_disconnect }
+
+      dispatcher.stream do |sse|
+        sse.patch_signals(foo: 'bar')
+      end
+
+      dispatcher.stream do |sse|
+        sse.patch_signals(bar: 'baz')
+      end
+
+      # open: false → first socket.<< raises Errno::EPIPE, simulating client gone
+      socket = TestSocket.new(open: false)
+      dispatcher.response.body.call(socket)
+      socket.wait_for_close
+      expect(events).to include(:client_disconnect)
+      expect(events).not_to include(:server_disconnect)
+    end
   end
 end
 


### PR DESCRIPTION
## Summary
Aligns `stream_many`'s callback semantics with `stream_one`'s mutually-exclusive contract: per stream lifecycle, exactly one of `on_server_disconnect` / `on_client_disconnect` / `on_error` fires, never a combination.

## The asymmetry

**Single-stream path** (`handling_sync_errors`, `dispatcher.rb:406-414`):

```ruby
def handling_sync_errors(generator, socket, &)
  yield
  @on_server_disconnect.each { |callable| callable.call(generator) }
rescue IOError, Errno::EPIPE, Errno::ECONNRESET
  @on_client_disconnect.each { |callable| callable.call(socket) }
rescue Exception => e
  @on_error.each { |callable| callable.call(e) }
end
```

Strictly mutually exclusive — the `rescue` branches make sure only one fires.

**Multi-stream path before this change** (`dispatcher.rb:374-378`):

```ruby
ensure
  @on_server_disconnect.each { |callable| callable.call(conn_generator) }
  @executor.stop(threads) if threads
  socket.close
end
```

The `ensure` block ran on every exit, *including* error and client-disconnect paths. So a streamer raising would fire both `on_error` *and* `on_server_disconnect`. A client disconnect would fire both `on_client_disconnect` *and* `on_server_disconnect`.

Consumers writing cleanup/observability against these callbacks see different behavior depending on whether they call `.stream` once or many times — a subtle source of bugs (e.g. duplicate metric increments, broadcasting "stream finished" notifications when the stream actually errored).

## Fix
Track a `completed_normally` flag in the control thread; flip it false in the same paths that already invoke `handle_streaming_error`; only fire `on_server_disconnect` in the `ensure` when the flag is still true.

\`\`\`ruby
completed_normally = true
# ...
elsif data.is_a?(Exception)
  completed_normally = false
  handle_streaming_error(data, socket)
  # ...
rescue Exception => e
  completed_normally = false
  handle_streaming_error(e, socket)
  # ...
ensure
  @on_server_disconnect.each { |callable| callable.call(conn_generator) } if completed_normally
\`\`\`

## Tests
2 new shared examples (run under both `ThreadExecutor` and `AsyncExecutor`, so 4 effective specs):

- streamer raises → `on_error` fires, `on_server_disconnect` does not
- client disconnects → `on_client_disconnect` fires, `on_server_disconnect` does not

Existing "spawns multiple streams in threads, triggering callbacks only once" still asserts `on_server_disconnect` fires on normal completion, so the happy path is regression-tested.

Full suite: 104 examples, 0 failures.

## Test plan
- [ ] CI green
- [ ] Existing `on_server_disconnect` happy-path test still passes
- [ ] New asymmetry tests pass under both executors