### PR TITLE
Raise ArgumentError on non-Hash/non-String patch_signals input

### DIFF
--- a/lib/datastar/server_sent_event_generator.rb
+++ b/lib/datastar/server_sent_event_generator.rb
@@ -115,6 +115,9 @@ module Datastar
         buffer << "data: signals #{signals}\n"
       when String
         multi_data_lines(signals, buffer, SIGNALS_DATALINE_LITERAL)
+      else
+        raise ArgumentError,
+              "patch_signals expects a Hash or a JSON-encoded String, got #{signals.class}"
       end
       write(buffer)
     end

--- a/spec/dispatcher_spec.rb
+++ b/spec/dispatcher_spec.rb
@@ -274,6 +274,22 @@ RSpec.describe Datastar::Dispatcher do
         %(data: signals }),
       ])
     end
+
+    # Pre-fix the case/when branch had no else, so non-Hash/non-String inputs
+    # silently produced an empty event (just the event: header, no data: line).
+    # The Dispatcher docstring already declares the contract: signals [Hash, String].
+    [
+      ['nil',     nil],
+      ['Array',   [1, 2, 3]],
+      ['Integer', 42],
+      ['Symbol',  :foo],
+    ].each do |label, value|
+      it "raises ArgumentError when signals is #{label}" do
+        sse = Datastar::ServerSentEventGenerator.new(StringIO.new, signals: {})
+        expect { sse.patch_signals(value) }
+          .to raise_error(ArgumentError, /Hash or a JSON-encoded String/)
+      end
+    end
   end
 
   describe '#remove_signals' do


### PR DESCRIPTION
Replaces closed #25 (couldn't reopen via API). Same change — see prior PR thread for full discussion.